### PR TITLE
Record inav support by major version, not minor

### DIFF
--- a/src/headers.rs
+++ b/src/headers.rs
@@ -363,9 +363,7 @@ impl Firmware {
             ),
             Some("inav") => (
                 Firmware::Inav(version),
-                crate::INAV_SUPPORT
-                    .iter()
-                    .any(|range| range.contains(&version)),
+                crate::INAV_SUPPORT.contains(&version),
             ),
             Some("emuflight") => {
                 tracing::error!("EmuFlight is not supported");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,8 +119,5 @@ const MARKER: &[u8] = b"H Product:Blackbox flight data recorder by Nicholas Sher
 
 const BETAFLIGHT_SUPPORT: Range<FirmwareVersion> =
     FirmwareVersion::new(4, 2, 0)..FirmwareVersion::new(4, 5, 0);
-const INAV_SUPPORT: &[Range<FirmwareVersion>] = &[
-    FirmwareVersion::new(5, 0, 0)..FirmwareVersion::new(5, 2, 0),
-    FirmwareVersion::new(6, 0, 0)..FirmwareVersion::new(6, 2, 0),
-    FirmwareVersion::new(7, 0, 0)..FirmwareVersion::new(7, 1, 0),
-];
+const INAV_SUPPORT: Range<FirmwareVersion> =
+    FirmwareVersion::new(5, 0, 0)..FirmwareVersion::new(8, 0, 0);


### PR DESCRIPTION
This makes the support ranges match the underlying `InternalFirmware` enum's granularity.