### PR TITLE
Support Betaflight 2025.12

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -46,7 +46,7 @@ impl Filter {
             Filter::OnlyFields(fields) => frame
                 .iter()
                 .enumerate()
-                .filter_map(|(i, field)| fields.0.contains(field.name).then_some(i))
+                .filter_map(|(i, field)| fields.0.contains(to_base_field(field.name)).then_some(i))
                 .collect(),
         }
     }


### PR DESCRIPTION
  ## Summary

  - Fix `Fields` filter ignoring fields with index suffixes (e.g. `gyroADC[0]`)
    by normalizing to the base field name before matching
  - Add support for Betaflight 2025.12 (new calendar versioning scheme)
    - Widen `FirmwareVersion::major` from `u8` to `u16` to accommodate year-based versions
    - Update enum mappings: 3 new flight modes (ALTHOLD, CHIRP, POS HOLD),
      new debug modes, OPTICALFLOW feature flag, ATTITUDE/SERVO disabled-field groups

  ## Testing

  Opened a 2025.12 log successfully. Full combination coverage not tested.