### PR TITLE
Fix Gyro/Motor divergence from blackbox_decode

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -260,6 +260,7 @@ fn skip_to_frame(data: &mut Reader) {
 pub(crate) struct MainFrameHistory {
     history: [Option<RawMainFrame>; 2],
     index_new: usize,
+    last_intra: Option<RawMainFrame>,
 }
 
 impl MainFrameHistory {
@@ -269,6 +270,14 @@ impl MainFrameHistory {
 
     fn push(&mut self, frame: RawMainFrame) -> &RawMainFrame {
         self.index_new = self.index_old();
+        if frame.intra {
+            // Betaflight resets both last and lastlast to the I-frame value so
+            // that the first P-frame after the I-frame boundary uses
+            // Average2(I, I) = I as its predictor, matching the encoder.
+            // This fixes issue #164
+            self.history[self.index_old()] = Some(frame.clone());
+            self.last_intra = Some(frame.clone());
+        }
         self.history[self.index_new] = Some(frame);
         self.last().unwrap()
     }
@@ -279,6 +288,10 @@ impl MainFrameHistory {
 
     pub(crate) fn last_last(&self) -> Option<&RawMainFrame> {
         self.history[self.index_old()].as_ref()
+    }
+
+    pub(crate) fn last_intra(&self) -> Option<&RawMainFrame> {
+        self.last_intra.as_ref()
     }
 }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -295,6 +295,41 @@ impl MainFrameHistory {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::*;
+
+    fn main_frame(intra: bool, iteration: u32, value: u32) -> RawMainFrame {
+        RawMainFrame {
+            intra,
+            iteration,
+            time: u64::from(iteration),
+            values: vec![value],
+        }
+    }
+
+    #[test]
+    fn intra_frames_keep_separate_intra_and_inter_history() {
+        let mut history = MainFrameHistory::default();
+
+        history.push(main_frame(true, 10, 100));
+        history.push(main_frame(false, 11, 101));
+        history.push(main_frame(false, 12, 102));
+
+        assert_eq!(Some(12), history.last().map(|frame| frame.iteration));
+        assert_eq!(Some(11), history.last_last().map(|frame| frame.iteration));
+        assert_eq!(Some(10), history.last_intra().map(|frame| frame.iteration));
+
+        history.push(main_frame(true, 20, 200));
+
+        assert_eq!(Some(20), history.last().map(|frame| frame.iteration));
+        assert_eq!(Some(20), history.last_last().map(|frame| frame.iteration));
+        assert_eq!(Some(20), history.last_intra().map(|frame| frame.iteration));
+    }
+}
+
 #[derive(Debug)]
 enum InternalFrame {
     Event(Event),

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -46,7 +46,7 @@ impl Filter {
             Filter::OnlyFields(fields) => frame
                 .iter()
                 .enumerate()
-                .filter_map(|(i, field)| fields.0.contains(field.name).then_some(i))
+                .filter_map(|(i, field)| fields.0.contains(to_base_field(field.name)).then_some(i))
                 .collect(),
         }
     }

--- a/src/frame/main/mod.rs
+++ b/src/frame/main/mod.rs
@@ -110,7 +110,7 @@ impl<'data, 'headers, 'parser> MainFrame<'data, 'headers, 'parser> {
 
 #[derive(Debug, Clone)]
 pub(crate) struct RawMainFrame {
-    intra: bool,
+    pub(crate) intra: bool,
     pub(crate) iteration: u32,
     pub(crate) time: u64,
     pub(crate) values: Vec<u32>,
@@ -127,7 +127,7 @@ impl RawMainFrame {
         let def = headers.main_frame_def();
 
         if kind == FrameKind::Data(DataFrameKind::Intra) {
-            def.parse_intra(data, headers, last)
+            def.parse_intra(data, headers, history.last_intra())
         } else {
             let skipped = 0; // FIXME
 


### PR DESCRIPTION
This PR fixes the issue #164 which presents a significat mismatch between `blackbox_decode` and this crate, for example having 54.2% mismatch from log `LOG00002.BFL` as @Gerry9000 pointed out (Thanks for that!).

## Solution
Betaflight's encoder resets both `last` and `lastlast` to the I-frame
value at the start of each I-frame group. The decoder's ring buffer was
not doing this — `lastlast` kept pointing at the final P-frame of the
previous group.

This caused every Average2-predicted P-frame immediately after an
I-frame boundary to use the wrong predictor:
  Average2(I_frame, old_P_frame)  ←  wrong
  Average2(I_frame, I_frame)      ←  correct

The error then accumulated through subsequent P-frames in the group as
each one's decoded value fed into the next frame's history. For
LOG00002.BFL (OMNIBUSF4, BF 4.2.6) this produced 119 494 / 220 311
(54.2%) mismatched gyroADC rows vs blackbox_decode, with a max delta
of 14 deg/s on the roll axis.

With this fix I no longer obtain any mismatch on tested logs `LOG00002.BFL` and `LOG00037.BFL`